### PR TITLE
fix: client editing and dynamic NOT targets

### DIFF
--- a/src/components/ClientForm.tsx
+++ b/src/components/ClientForm.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { zodResolver } from '@hookform/resolvers/zod'
 import * as z from 'zod'
@@ -64,6 +64,19 @@ export function ClientForm({ onSubmit, client, isEditing = false }: ClientFormPr
       nots_generated: 0,
     }
   })
+
+  useEffect(() => {
+    if (client) {
+      form.reset({
+        name: client.name,
+        margin_in: client.margin_in,
+        overall_margin: client.overall_margin,
+        invested_amount: client.invested_amount,
+        monthly_revenue: client.monthly_revenue,
+        nots_generated: client.nots_generated,
+      })
+    }
+  }, [client, form])
 
   if (!isAdmin) return null
 

--- a/src/components/ui/command.tsx
+++ b/src/components/ui/command.tsx
@@ -21,7 +21,7 @@ const Command = React.forwardRef<
 ))
 Command.displayName = CommandPrimitive.displayName
 
-interface CommandDialogProps extends DialogProps {}
+type CommandDialogProps = DialogProps
 
 const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -2,8 +2,7 @@ import * as React from "react"
 
 import { cn } from "@/lib/utils"
 
-export interface TextareaProps
-  extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {}
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>
 
 const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
   ({ className, ...props }, ref) => {

--- a/src/hooks/useDashboard.ts
+++ b/src/hooks/useDashboard.ts
@@ -1,6 +1,18 @@
 import { useState, useEffect } from 'react'
 import { supabase } from '@/lib/supabase'
-import { DashboardStats } from '@/types'
+import { DashboardStats, Client } from '@/types'
+
+const getWorkingDaysInMonth = (date: Date) => {
+  const year = date.getFullYear()
+  const month = date.getMonth()
+  const daysInMonth = new Date(year, month + 1, 0).getDate()
+  let count = 0
+  for (let day = 1; day <= daysInMonth; day++) {
+    const d = new Date(year, month, day).getDay()
+    if (d !== 0 && d !== 6) count++
+  }
+  return count
+}
 
 export function useDashboard() {
   const [stats, setStats] = useState<DashboardStats | null>(null)
@@ -10,24 +22,61 @@ export function useDashboard() {
   const fetchDashboardStats = async () => {
     try {
       setLoading(true)
-      const { data, error } = await supabase
-        .from('dashboard_stats')
+      const { data: clients, error } = await supabase
+        .from('clients')
         .select('*')
-        .single()
 
       if (error) throw error
-      setStats(data)
+
+      const totals = (clients as Client[] | null)?.reduce((acc, c) => ({
+        margin_in: acc.margin_in + Number(c.margin_in),
+        overall_margin: acc.overall_margin + Number(c.overall_margin),
+        revenue: acc.revenue + Number(c.monthly_revenue),
+        nots: acc.nots + Number(c.nots_generated)
+      }), { margin_in: 0, overall_margin: 0, revenue: 0, nots: 0 }) || { margin_in: 0, overall_margin: 0, revenue: 0, nots: 0 }
+
+      const target_nots = Math.round(totals.margin_in * 0.18)
+      const workingDays = getWorkingDaysInMonth(new Date())
+      const daily_target = workingDays > 0 ? Math.round(target_nots / workingDays) : 0
+      const weekly_target = daily_target * 5
+
+      const progress_percentage = target_nots > 0 ? (totals.nots / target_nots) * 100 : 0
+
+      setStats({
+        total_clients: clients ? clients.length : 0,
+        total_margin_in: totals.margin_in,
+        total_overall_margin: totals.overall_margin,
+        total_monthly_revenue: totals.revenue,
+        total_nots: totals.nots,
+        target_nots,
+        progress_percentage,
+        daily_target_nots: daily_target,
+        weekly_target_nots: weekly_target
+      })
     } catch (err) {
       setError(err instanceof Error ? err.message : 'An error occurred')
-      // Fallback to sample data if database is not set up yet
+
+      const fallbackTotals = {
+        margin_in: 2450000,
+        overall_margin: 3100000,
+        revenue: 890000,
+        nots: 142
+      }
+      const target_nots = Math.round(fallbackTotals.margin_in * 0.18)
+      const workingDays = getWorkingDaysInMonth(new Date())
+      const daily_target = workingDays > 0 ? Math.round(target_nots / workingDays) : 0
+      const weekly_target = daily_target * 5
+
       setStats({
         total_clients: 12,
-        total_margin_in: 2450000,
-        total_overall_margin: 3100000,
-        total_monthly_revenue: 890000,
-        total_nots: 142,
-        target_nots: 600,
-        progress_percentage: 23.67
+        total_margin_in: fallbackTotals.margin_in,
+        total_overall_margin: fallbackTotals.overall_margin,
+        total_monthly_revenue: fallbackTotals.revenue,
+        total_nots: fallbackTotals.nots,
+        target_nots,
+        progress_percentage: target_nots > 0 ? (fallbackTotals.nots / target_nots) * 100 : 0,
+        daily_target_nots: daily_target,
+        weekly_target_nots: weekly_target
       })
     } finally {
       setLoading(false)

--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -139,8 +139,12 @@ export default function Dashboard() {
                   <span className="font-medium">{stats.target_nots - stats.total_nots}</span>
                 </div>
                 <div className="flex justify-between text-sm">
-                  <span className="text-muted-foreground">Target per client:</span>
-                  <span className="font-medium">50 NOTs</span>
+                  <span className="text-muted-foreground">Daily target:</span>
+                  <span className="font-medium">{stats.daily_target_nots}</span>
+                </div>
+                <div className="flex justify-between text-sm">
+                  <span className="text-muted-foreground">Weekly target:</span>
+                  <span className="font-medium">{stats.weekly_target_nots}</span>
                 </div>
               </div>
             </div>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -49,4 +49,6 @@ export interface DashboardStats {
   total_nots: number;
   target_nots: number;
   progress_percentage: number;
+  daily_target_nots: number;
+  weekly_target_nots: number;
 }

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -1,4 +1,5 @@
 import type { Config } from "tailwindcss";
+import tailwindcssAnimate from "tailwindcss-animate";
 
 export default {
 	darkMode: ["class"],
@@ -113,5 +114,5 @@ export default {
 			}
 		}
 	},
-	plugins: [require("tailwindcss-animate")],
+        plugins: [tailwindcssAnimate],
 } satisfies Config;


### PR DESCRIPTION
## Summary
- ensure client edit form resets with latest data
- compute NOT targets from total margin (18%) and expose daily/weekly goals
- clean up lint warnings in shared UI components

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_689343fdabe48333904b639f0d6f6f69